### PR TITLE
DS-2648 Personal pronoun input with no entity bug fix

### DIFF
--- a/man/NERAnnotate.Rd
+++ b/man/NERAnnotate.Rd
@@ -41,11 +41,15 @@ document then an empty data.frame with no rows is returned.
 }
 \examples{
 \dontrun{
+simple.input.test <- c("John is a person", "Google is a company", "This is nothing")
+input.file <- tempfile()
 file <- file(input.file, "wb") # need linux style line endings
 writeLines(simple.input.test, con = file)
 close(file)
-keys <- c("ssplit.eolonly", "annotators", "outputFormat", "file", "outputDirectory")
-values <- c("true", "tokenize,ssplit,pos,lemma,ner", "json", input.file, dirname(tmp.file))
+keys <- c("ssplit.eolonly", "annotators", "outputFormat", "file", "outputDirectory",
+          "output.prettyPrint")
+values <- c("true", "tokenize,ssplit,pos,lemma,ner", "json", input.file, dirname(input.file),
+            "true")
 
 cnlp_init_corenlp_custom(language = "en", mem = "2g", keys = keys, values = values)
 simple.output <- NERAnnotate(input.file)

--- a/tests/testthat/test-entity.R
+++ b/tests/testthat/test-entity.R
@@ -24,6 +24,7 @@ simple.with.pronouns.expected <- structure(list(id = c(1L, 1L, 3L, 4L, 4L, 4L),
                              class = "data.frame",
                              row.names = c(NA, -6L))
 
+pronouns <- c("he's", "hes", "he is", "He is", "He Is", "she's", "She is")
 
 none.expected <- data.frame(id = character(), entity = character(), entity.type = character())
 
@@ -63,4 +64,10 @@ test_that("NERAnnotate consistency", {
   none.output <- NERAnnotate(tmp.file)
   expect_identical(none.output, none.expected)
   
+  file <- file(tmp.file, "wb")
+  writeLines(pronouns, con = file)
+  close(file)
+  
+  expect_error(pronoun.output.after.validation <- NERAnnotate(tmp.file, entity.mentions.only = FALSE), NA)
+  expect_identical(pronoun.output.after.validation, none.expected)
 })


### PR DESCRIPTION
NER annotator parser had a bug when input text vector had personal pronouns but no entities when validated against the token output (when `entity.mentions.only = FALSE`, the default setting). Fixed the `NERAnnotate` function to handle such a case and added unit test.

Housekeeping fixes

* Improved code style in NERAnnotate
* Completed example of NERAnnotate.